### PR TITLE
Usprawnienia UART 

### DIFF
--- a/application.h
+++ b/application.h
@@ -12,6 +12,9 @@ http://mozilla.org/MPL/2.0/.
 #include "applicationmode.h"
 #include "PyInt.h"
 #include "network/manager.h"
+#ifdef WITH_UART
+#include "uart.h"
+#endif
 
 class eu07_application {
 	const int MAX_NETWORK_PER_FRAME = 1000;
@@ -99,6 +102,9 @@ public:
         is_server() const;
     bool
         is_client() const;
+#ifdef WITH_UART
+    UartStatus uart_status;
+#endif
 
 private:
 // types

--- a/drivermode.cpp
+++ b/drivermode.cpp
@@ -124,7 +124,7 @@ driver_mode::drivermode_input::command_fallback( user_command const Command ) co
     if( lookup == commandfallbacks.end() ) {
         return { user_command::none, user_command::none };
     }
-    
+
     return lookup->second;
 }
 
@@ -613,7 +613,7 @@ driver_mode::update_camera( double const Deltatime ) {
         // debug camera
         DebugCamera.Update();
     }
-                                               
+
     // reset window state, it'll be set again if applicable in a check below
     Global.CabWindowOpen = false;
 
@@ -814,8 +814,8 @@ driver_mode::OnKeyDown(int cKey) {
     switch (cKey) {
 
         case GLFW_KEY_F4: {
-            
-            if( Global.shiftState ) { ExternalView(); } // with Shift, cycle through external views 
+
+            if( Global.shiftState ) { ExternalView(); } // with Shift, cycle through external views
             else                    { InOutKey(); } // without, step out of the cab or return to it
             break;
         }
@@ -850,7 +850,7 @@ driver_mode::OnKeyDown(int cKey) {
         }
         case GLFW_KEY_F6: {
             // przyspieszenie symulacji do testowania scenerii... uwaga na FPS!
-            if( DebugModeFlag ) { 
+            if( DebugModeFlag ) {
 
                 if( Global.ctrlState ) { Global.fTimeSpeed = ( Global.shiftState ? 60.0 : 20.0 ); }
                 else                   { Global.fTimeSpeed = ( Global.shiftState ? 5.0 : 1.0 ); }
@@ -915,7 +915,7 @@ driver_mode::DistantView( bool const Near ) {
         ( simulation::Train != nullptr ) ?
             simulation::Train->Dynamic() :
             pDynamicNearest ) };
-    
+
     if( vehicle == nullptr ) { return; }
 
     auto const cab =
@@ -1081,7 +1081,7 @@ driver_mode::CabView() {
     m_externalview = false;
 
     // likwidacja obrotów - patrzy horyzontalnie na południe
-    Camera.Reset(); 
+    Camera.Reset();
 
     // bind camera with the vehicle
     Camera.m_owner = train->Dynamic();

--- a/driveruilayer.cpp
+++ b/driveruilayer.cpp
@@ -75,7 +75,6 @@ driver_ui::on_key_( int const Key, int const Scancode, int const Action, int con
     }
 
     switch (Key) {
-            
         case GLFW_KEY_F1: {
             // basic consist info
             auto state = (
@@ -83,7 +82,7 @@ driver_ui::on_key_( int const Key, int const Scancode, int const Action, int con
                 ( m_aidpanel.is_expanded == false ) ? 1 :
                 2 );
             state = clamp_circular( ++state, 3 );
-            
+
             m_aidpanel.is_open = ( state > 0 );
             m_aidpanel.is_expanded = ( state > 1 );
 
@@ -97,7 +96,7 @@ driver_ui::on_key_( int const Key, int const Scancode, int const Action, int con
                 ( m_timetablepanel.is_expanded == false ) ? 1 :
                 2 );
             state = clamp_circular( ++state, 3 );
-            
+
             m_timetablepanel.is_open = ( state > 0 );
             m_timetablepanel.is_expanded = ( state > 1 );
 

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -31,6 +31,11 @@ http://mozilla.org/MPL/2.0/.
 #include "utilities.h"
 #include "Logs.h"
 
+#ifdef WITH_UART
+#include "uart.h"
+#endif
+
+
 void
 drivingaid_panel::update() {
 
@@ -546,7 +551,9 @@ debug_panel::update() {
     m_powergridlines.clear();
     m_cameralines.clear();
     m_rendererlines.clear();
+#ifdef WITH_UART
     m_uartlines.clear();
+#endif
 
     update_section_vehicle( m_vehiclelines );
     update_section_engine( m_enginelines );
@@ -557,7 +564,9 @@ debug_panel::update() {
     update_section_powergrid( m_powergridlines );
     update_section_camera( m_cameralines );
     update_section_renderer( m_rendererlines );
+#ifdef WITH_UART
     update_section_uart(m_uartlines);
+#endif
 }
 
 void
@@ -641,6 +650,7 @@ debug_panel::render() {
                     avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
                 }
                 ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+                ImGui::Combo("Baud", &Application.uart_status.selected_baud_index, uart_baudrates_list, uart_baudrates_list_num);
             }
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -634,6 +634,14 @@ debug_panel::render() {
         render_section_settings();
 #ifdef WITH_UART
         if(true == render_section( "UART", m_uartlines)) {
+            int ports_num = Application.uart_status.available_ports.size();
+            if(ports_num > 0) {
+                char **avlports = new char*[ports_num];
+                for (int i=0; i < ports_num; i++) {
+                    avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
+                }
+                ImGui::ListBox("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+            }
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }
 #endif
@@ -1233,24 +1241,26 @@ debug_panel::update_section_scantable( std::vector<text_line> &Output ) {
 #ifdef WITH_UART
 void
 debug_panel::update_section_uart( std::vector<text_line> &Output ) {
+    UartStatus *status = &Application.uart_status;
+
     Output.emplace_back(
-        ("Port: " + Application.uart_status.port_name).c_str(),
+        ("Port: " + status->port_name).c_str(),
         Global.UITextColor
     );
     Output.emplace_back(
-        ("Baud: " + std::to_string(Application.uart_status.baud)).c_str(),
+        ("Baud: " + std::to_string(status->baud)).c_str(),
         Global.UITextColor
     );
-    if(Application.uart_status.is_connected) {
-        std::string synctext = Application.uart_status.is_synced ? "SYNCED" : "NOT SYNCED";
+    if(status->is_connected) {
+        std::string synctext = status->is_synced ? "SYNCED" : "NOT SYNCED";
         Output.emplace_back(("CONNECTED, " + synctext).c_str(), Global.UITextColor);
     } else {
         Output.emplace_back("* NOT CONNECTED *", Global.UITextColor);
     }
     Output.emplace_back(
         (
-            "Packets sent: "+std::to_string(Application.uart_status.packets_sent)
-            +" Packets received: "+std::to_string(Application.uart_status.packets_received)
+            "Packets sent: "+std::to_string(status->packets_sent)
+            +" Packets received: "+std::to_string(status->packets_received)
         ).c_str(),
         Global.UITextColor
     );

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -640,7 +640,7 @@ debug_panel::render() {
                 for (int i=0; i < ports_num; i++) {
                     avlports[i] = (char *) Application.uart_status.available_ports[i].c_str();
                 }
-                ImGui::ListBox("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
+                ImGui::Combo("Port", &Application.uart_status.selected_port_index, avlports, ports_num);
             }
             ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }

--- a/driveruipanels.cpp
+++ b/driveruipanels.cpp
@@ -634,7 +634,7 @@ debug_panel::render() {
         render_section_settings();
 #ifdef WITH_UART
         if(true == render_section( "UART", m_uartlines)) {
-            //ImGui::Checkbox("Enabled", &Global.uart_conf.enable);
+            ImGui::Checkbox("Enabled", &Application.uart_status.enabled);
         }
 #endif
         // toggles
@@ -1233,8 +1233,14 @@ debug_panel::update_section_scantable( std::vector<text_line> &Output ) {
 #ifdef WITH_UART
 void
 debug_panel::update_section_uart( std::vector<text_line> &Output ) {
-    Output.emplace_back(("Port: " + Global.uart_conf.port).c_str(), Global.UITextColor);
-    Output.emplace_back(("Baud: " + std::to_string(Global.uart_conf.baud)).c_str(), Global.UITextColor);
+    Output.emplace_back(
+        ("Port: " + Application.uart_status.port_name).c_str(),
+        Global.UITextColor
+    );
+    Output.emplace_back(
+        ("Baud: " + std::to_string(Application.uart_status.baud)).c_str(),
+        Global.UITextColor
+    );
     if(Application.uart_status.is_connected) {
         std::string synctext = Application.uart_status.is_synced ? "SYNCED" : "NOT SYNCED";
         Output.emplace_back(("CONNECTED, " + synctext).c_str(), Global.UITextColor);

--- a/driveruipanels.h
+++ b/driveruipanels.h
@@ -91,6 +91,9 @@ private:
     void update_section_powergrid( std::vector<text_line> &Output );
     void update_section_camera( std::vector<text_line> &Output );
     void update_section_renderer( std::vector<text_line> &Output );
+#ifdef WITH_UART
+    void update_section_uart( std::vector<text_line> &Output );
+#endif
     // section update helpers
     std::string update_vehicle_coupler( int const Side );
     std::string update_vehicle_brake() const;
@@ -99,6 +102,9 @@ private:
     bool render_section( std::vector<text_line> const &Lines );
     bool render_section_scenario();
     bool render_section_eventqueue();
+#ifdef WITH_UART
+    bool render_section_uart();
+#endif
     bool render_section_settings();
 // members
     std::array<char, 1024> m_buffer;
@@ -113,7 +119,12 @@ private:
         m_scenariolines,
         m_eventqueuelines,
         m_powergridlines,
+ #ifdef WITH_UART
+        m_rendererlines,
+        m_uartlines;
+ #else
         m_rendererlines;
+ #endif
     int tprev { 0 }; // poprzedni czas
     double VelPrev { 0.0 }; // poprzednia prędkość
     double Acc { 0.0 }; // przyspieszenie styczne

--- a/uart.cpp
+++ b/uart.cpp
@@ -7,6 +7,7 @@
 #include "parser.h"
 #include "Logs.h"
 #include "simulationtime.h"
+#include "application.h"
 
 uart_input::uart_input()
 {
@@ -29,6 +30,7 @@ bool uart_input::setup_port()
 
     if (sp_get_port_by_name(conf.port.c_str(), &port) != SP_OK) {
         if(!error_notified) {
+            Application.uart_status.is_connected = false;
             ErrorLog("uart: cannot find specified port '"+conf.port+"'");
         }
         error_notified = true;
@@ -37,6 +39,7 @@ bool uart_input::setup_port()
 
     if (sp_open(port, (sp_mode)(SP_MODE_READ | SP_MODE_WRITE)) != SP_OK) {
         if(!error_notified) {
+            Application.uart_status.is_connected = false;
             ErrorLog("uart: cannot open port '"+conf.port+"'");
         }
         error_notified = true;
@@ -54,6 +57,7 @@ bool uart_input::setup_port()
 		sp_set_config_parity(config, SP_PARITY_NONE) != SP_OK ||
 		sp_set_config(port, config) != SP_OK) {
         if(!error_notified) {
+            Application.uart_status.is_connected = false;
             ErrorLog("uart: cannot set config");
         }
         error_notified = true;
@@ -65,6 +69,7 @@ bool uart_input::setup_port()
 
     if (sp_flush(port, SP_BUF_BOTH) != SP_OK) {
         if(!error_notified) {
+            Application.uart_status.is_connected = false;
             ErrorLog("uart: cannot flush");
         }
         error_notified = true;
@@ -72,7 +77,11 @@ bool uart_input::setup_port()
         return false;
     }
 
-    error_notified = false;
+    if(error_notified || !Application.uart_status.is_connected) {
+        error_notified = false;
+        ErrorLog("uart: connected to '"+conf.port+"'");
+        Application.uart_status.is_connected = true;
+    }
 
     return true;
 }
@@ -205,11 +214,13 @@ void uart_input::poll()
 
 		bool sync;
 		if (tmp_buffer[0] != 0xEF || tmp_buffer[1] != 0xEF || tmp_buffer[2] != 0xEF || tmp_buffer[3] != 0xEF) {
+            Application.uart_status.is_synced = false;
 			if (conf.debug)
 				WriteLog("uart: bad sync");
 			sync = false;
 		}
 		else {
+            Application.uart_status.is_synced = true;
 			if (conf.debug)
 				WriteLog("uart: sync ok");
 			sync = true;
@@ -253,6 +264,7 @@ void uart_input::poll()
 
 		std::array<uint8_t, 16> buffer;
 		memmove(&buffer[0], &tmp_buffer[4], 16);
+        Application.uart_status.packets_received++;
 
 		if (conf.debug)
 		{
@@ -450,7 +462,12 @@ void uart_input::poll()
         setup_port();
         return;
       }
+        Application.uart_status.packets_sent++;
 
 		data_pending = true;
 	}
+}
+
+bool uart_input::is_connected() {
+    return (port != nullptr);
 }

--- a/uart.h
+++ b/uart.h
@@ -15,6 +15,8 @@ class UartStatus {
         bool is_synced = false;
         unsigned long packets_sent = 0;
         unsigned long packets_received = 0;
+
+        void reset_stats();
 };
 
 class uart_input

--- a/uart.h
+++ b/uart.h
@@ -3,12 +3,17 @@
 #include <libserialport.h>
 #include "command.h"
 
+extern const char* uart_baudrates_list[];
+extern const size_t uart_baudrates_list_num;
+
 class UartStatus {
     public:
         std::string port_name = "";
         std::vector<std::string> available_ports = {};
         int selected_port_index = -1;
+        int selected_baud_index = -1;
         int active_port_index = -1;
+        int active_baud_index = -1;
         int baud = 0;
         bool enabled = false;
         bool is_connected = false;

--- a/uart.h
+++ b/uart.h
@@ -5,6 +5,9 @@
 
 class UartStatus {
     public:
+        std::string port_name = "";
+        int baud = 0;
+        bool enabled = false;
         bool is_connected = false;
         bool is_synced = false;
         unsigned long packets_sent = 0;

--- a/uart.h
+++ b/uart.h
@@ -62,7 +62,7 @@ private:
 
     using input_pin_t = std::tuple<std::size_t, input_type_t, user_command, user_command>;
     using inputpin_sequence = std::vector<input_pin_t>;
-    
+
     bool setup_port();
 
 // members
@@ -71,7 +71,9 @@ private:
     command_relay relay;
     std::array<std::uint8_t, 16> old_packet; // TBD, TODO: replace with vector of configurable size?
     std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_setup;
     conf_t conf;
 	bool data_pending = false;
+    bool error_notified = false;
     std::uint8_t m_trainstatecab { 0 }; // helper, keeps track of last active cab. 0: front cab, 1: rear cab
 };

--- a/uart.h
+++ b/uart.h
@@ -6,6 +6,9 @@
 class UartStatus {
     public:
         std::string port_name = "";
+        std::vector<std::string> available_ports = {};
+        int selected_port_index = -1;
+        int active_port_index = -1;
         int baud = 0;
         bool enabled = false;
         bool is_connected = false;
@@ -77,6 +80,7 @@ private:
     using inputpin_sequence = std::vector<input_pin_t>;
 
     bool setup_port();
+    void enumerate_ports();
 
 // members
     sp_port *port = nullptr;
@@ -85,6 +89,7 @@ private:
     std::array<std::uint8_t, 16> old_packet; // TBD, TODO: replace with vector of configurable size?
     std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
     std::chrono::time_point<std::chrono::high_resolution_clock> last_setup;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_enumeration;
     conf_t conf;
 	bool data_pending = false;
     bool error_notified = false;

--- a/uart.h
+++ b/uart.h
@@ -3,6 +3,14 @@
 #include <libserialport.h>
 #include "command.h"
 
+class UartStatus {
+    public:
+        bool is_connected = false;
+        bool is_synced = false;
+        unsigned long packets_sent = 0;
+        unsigned long packets_received = 0;
+};
+
 class uart_input
 {
 public:
@@ -50,6 +58,8 @@ public:
         recall_bindings();
     void
         poll();
+    bool
+        is_connected();
 
 private:
 // types

--- a/uart.h
+++ b/uart.h
@@ -82,7 +82,7 @@ private:
     using inputpin_sequence = std::vector<input_pin_t>;
 
     bool setup_port();
-    void enumerate_ports();
+    void find_ports();
 
 // members
     sp_port *port = nullptr;
@@ -91,7 +91,7 @@ private:
     std::array<std::uint8_t, 16> old_packet; // TBD, TODO: replace with vector of configurable size?
     std::chrono::time_point<std::chrono::high_resolution_clock> last_update;
     std::chrono::time_point<std::chrono::high_resolution_clock> last_setup;
-    std::chrono::time_point<std::chrono::high_resolution_clock> last_enumeration;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_port_find;
     conf_t conf;
 	bool data_pending = false;
     bool error_notified = false;


### PR DESCRIPTION
Dzień dobry, panie TMJ. Podsyłam propozycję usprawnień obsługi UART.

1. UI / Debug Panel: dodana sekcja UART z możliwością zmiany portu, baud rate, wstrzymania transmisji i z krótkim podsumowaniem stanu transmisji
2. Korekty obsługi UART, dzięki którym można podłączyć i odłączyć interfejs w trakcie działania symulatora.

Dzięki tym zmianom o wiele łatwiej prowadzić jest prace nad sprzętowymi pulpitami (można przełączać się między płytką prototypową, można zatrzymać transmisję i wgrać nowszy firmware bez wyłączania symulacji), oraz w razie przypadkowego rozłączenia komunikacji można bez problemu kontynuować jazdę bez pulpitu lub po jego ponownym połączeniu.

Uwagi:
- kompilację robiłem na linuxie, niestety nie miałem możliwości sprawdzić na Windowsie
- lista portów pobierana jest przez sp_list_ports() z libserialport. Na linuxie działa, na Windowsie nie miałem jak sprawdzić.